### PR TITLE
Fix scikit-learn requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ terminaltables
 pytorch_pfn_extras
 fastargs
 matplotlib
-sklearn
+scikit-learn
 imgcat
 pandas
 assertpy


### PR DESCRIPTION
I got following error when installing requirements.txt

```
root@debian:/workspaces/ffcv-imagenet# pip install -r requirements.txt 
Collecting terminaltables (from -r requirements.txt (line 1))
  Downloading terminaltables-3.1.10-py2.py3-none-any.whl (15 kB)
Collecting pytorch_pfn_extras (from -r requirements.txt (line 2))
  Downloading pytorch-pfn-extras-0.7.4.tar.gz (151 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 151.2/151.2 kB 6.4 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting fastargs (from -r requirements.txt (line 3))
  Downloading fastargs-1.2.0.tar.gz (12 kB)
  Preparing metadata (setup.py) ... done
Requirement already satisfied: matplotlib in /opt/conda/lib/python3.10/site-packages (from -r requirements.txt (line 4)) (3.7.2)
Collecting sklearn (from -r requirements.txt (line 5))
  Downloading sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

As mentioned [here](https://pypi.org/project/sklearn/), sklearn should be installed by `pip install scikit-learn`.
