### PR TITLE
resolve deprecated compute_on_step

### DIFF
--- a/train_imagenet.py
+++ b/train_imagenet.py
@@ -416,9 +416,9 @@ class ImageNetTrainer:
     @param('logging.folder')
     def initialize_logger(self, folder):
         self.val_meters = {
-            'top_1': torchmetrics.Accuracy(task='multiclass', num_classes=1000, compute_on_step=False).to(self.gpu),
-            'top_5': torchmetrics.Accuracy(task='multiclass', num_classes=1000, compute_on_step=False, top_k=5).to(self.gpu),
-            'loss': MeanScalarMetric(compute_on_step=False).to(self.gpu)
+            'top_1': torchmetrics.Accuracy(task='multiclass', num_classes=1000).to(self.gpu),
+            'top_5': torchmetrics.Accuracy(task='multiclass', num_classes=1000, top_k=5).to(self.gpu),
+            'loss': MeanScalarMetric().to(self.gpu)
         }
 
         if self.gpu == 0:


### PR DESCRIPTION
Hi, 
Start from [here](https://github.com/Lightning-AI/torchmetrics/issues/789) `compute_on_step` is deprecated. New version of torchmetrics will rase 
`ValueError: Unexpected keyword arguments: compute_on_step.`

Quick fix is to remove them to be compatible with the new version(1.4.0): e.g.
https://github.com/libffcv/ffcv-imagenet/blob/4dd291a122096a2032ec9fd19633e1b9aff3577d/train_imagenet.py#L419